### PR TITLE
Relax QuickCheck bounds

### DIFF
--- a/superbuffer.cabal
+++ b/superbuffer.cabal
@@ -48,7 +48,7 @@ test-suite spec
       base >= 4.8 && < 5
     , bytestring < 0.11
     , HTF < 0.14
-    , QuickCheck < 2.11
+    , QuickCheck < 2.13
     , async
     , superbuffer
   default-language: Haskell2010


### PR DESCRIPTION
I've tested with QuickCheck 2.12 and all tests pass.
This allows superbuffer to build on the latest Haskell LTS.