### PR TITLE
Bump upper bounds of dependencies bytestring, HTF, QuickCheck

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ extra-source-files:
 
 dependencies:
   - base >= 4.8 && < 5
-  - bytestring < 0.11
+  - bytestring < 0.12
 
 ghc-options: -Wall
 
@@ -32,8 +32,8 @@ tests:
     main: Test.hs
     source-dirs: test
     dependencies:
-      - HTF < 0.14
-      - QuickCheck < 2.10
+      - HTF < 0.16
+      - QuickCheck < 2.15
       - async
       - superbuffer
     ghc-options: -funfolding-use-threshold=16 -O2 -optc-Ofast

--- a/superbuffer.cabal
+++ b/superbuffer.cabal
@@ -1,4 +1,6 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
@@ -14,12 +16,10 @@ copyright:      2016 - 2017 Alexander Thiemann <mail@athiemann.net>
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
-
 extra-source-files:
-    package.yaml
     README.md
     stack.yaml
+    package.yaml
 
 library
   hs-source-dirs:
@@ -28,8 +28,8 @@ library
   c-sources:
       cbits/superbuffer.c
   build-depends:
-      base >= 4.8 && < 5
-    , bytestring < 0.11
+      base >=4.8 && <5
+    , bytestring <0.12
   exposed-modules:
       Data.ByteString.SuperBuffer
       Data.ByteString.SuperBuffer.Pure
@@ -40,30 +40,34 @@ library
 test-suite spec
   type: exitcode-stdio-1.0
   main-is: Test.hs
+  other-modules:
+      Paths_superbuffer
   hs-source-dirs:
       test
   ghc-options: -Wall -funfolding-use-threshold=16 -O2 -optc-Ofast
   cpp-options: -DTest
   build-depends:
-      base >= 4.8 && < 5
-    , bytestring < 0.11
-    , HTF < 0.14
-    , QuickCheck < 2.13
+      HTF <0.16
+    , QuickCheck <2.15
     , async
+    , base >=4.8 && <5
+    , bytestring <0.12
     , superbuffer
   default-language: Haskell2010
 
 benchmark sbuf-bench
   type: exitcode-stdio-1.0
   main-is: Bench.hs
+  other-modules:
+      Paths_superbuffer
   hs-source-dirs:
       bench
   ghc-options: -Wall -funfolding-use-threshold=16 -O2 -optc-Ofast
   build-depends:
-      base >= 4.8 && < 5
-    , bytestring < 0.11
-    , criterion < 1.3
-    , superbuffer
+      async
+    , base >=4.8 && <5
     , buffer-builder
-    , async
+    , bytestring <0.12
+    , criterion <1.3
+    , superbuffer
   default-language: Haskell2010


### PR DESCRIPTION
I ran with the latest version of those dependencies and the tests pass. I didn't run benchmarks but I imagine we also need to bump major version of criterion.